### PR TITLE
Re-enable FilePathsBase workflows

### DIFF
--- a/src/repos.config
+++ b/src/repos.config
@@ -17,3 +17,4 @@ JuliaEcosystem/PkgDeps.jl
 JuliaRegistries/CompatHelper.jl
 JuliaWeb/GitForge.jl
 JuliaWeb/Retry.jl
+rofinn/FilePathsBase.jl


### PR DESCRIPTION
I could also set up a separate stack for this, but this seems easier. I guess I also need to setup a token for this?