### PR TITLE
Reduce run rate from 59 days -> 20 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Automatically prevent your scheduled GitHub Actions from becoming disabled after
 ## Overview
 
 This package is meant to be deployed in an AWS environment.
-It contains a Lambda function which will run every `59 days`.
+It contains a Lambda function which will run every `20 days`.
 The Lambda function gets GitHub repositories belonging to an organization and hits the [enable workflow](https://docs.github.com/en/rest/reference/actions#enable-a-workflow) REST endpoint to re-enable the GitHub Actions workflow of each repository.
 Additionally, you can re-enable workflows for a repository outside of your organization by modifying the `src/repos.config` file with a list of `GitHub_Organization/Repository_Name` entries.
 ## Installation

--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,7 @@ Resources:
         Schedule:
           Type: Schedule
           Properties:
-            Schedule: 'rate(59 days)'
+            Schedule: 'rate(20 days)'
       Role: !GetAtt KeepActionsAliveRole.Arn
       Timeout: 180  # 3 minutes
       MemorySize: 1024


### PR DESCRIPTION
I was just thinking about this solution and at the current execution date (59 days) it's a bit less than ideal. If a workflow is disabled we might be sitting for almost 2 months before it is re-enabled and we see some errors cropping up.

We should reduce this rate, I picked 20 days, to allow this to run more frequently and ensure things are turned on.